### PR TITLE
Fix `nightly` CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,17 +1,15 @@
 name: Docs
 
 on:
-  pull_request:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 permissions:
-    contents: read
-    pages: write
-    id-token: write
-      
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   deploy:
     name: Docs Zig Release
@@ -25,13 +23,13 @@ jobs:
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.12.0
+          version: 0.13.0
       - name: Build docs
         run: zig build docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './zig-out/docs'
+          path: "./zig-out/docs"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/nightly_ci.yml
+++ b/.github/workflows/nightly_ci.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: "nightly"
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
       - name: Run Tests
-        continue-on-error: true
         run: zig build test
       - name: Check Formatting
-        continue-on-error: true
         run: zig fmt --check .
   examples:
     name: Examples
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: "nightly"
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
       - name: Run Enemy Spawner

--- a/README.md
+++ b/README.md
@@ -134,14 +134,14 @@ using the `zig fetch` command.
 The `main` branch tracks the latest release of Zig (currently v0.13.0) and can be added
 as follows:
 
-```bash
+```
 zig fetch --save git+https://github.com/pblischak/zprob/
 ```
 
 The `nightly` branch tracks the Zig `master` branch and can be added by adding `#nightly` to the
 git URL:
 
-```bash
+```
 zig fetch --save git+https://github.com/pblischak/zprob/#nightly
 ```
 


### PR DESCRIPTION
The CI steps for building a nightly version of `zprob` against the `master` Zig branch needed to actually checkout `ref: nightly` in the CI steps.